### PR TITLE
Silence Bandit false positives and harden PyPI URL opens

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -36,6 +36,10 @@ jobs:
       with:
         exit_zero: true  # optional, default is DEFAULT
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information.
+        # Tests rely on pytest's `assert`, and the generated trees are excluded
+        # from every other linter (see CLAUDE.md) so Bandit matches.
+        excluded_paths: 'tests,aws_resource_validator/pydantic_models,aws_resource_validator/class_definitions.py'
+        skips: 'B101'
 
     - name: Check for Issues in SARIF
       id: check_sarif

--- a/aws_resource_validator/generator/common/templates.py
+++ b/aws_resource_validator/generator/common/templates.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Mapping
 from functools import cache
 from pathlib import Path
 
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 
 
 @cache
@@ -22,7 +22,7 @@ def get_environment(template_dir: str) -> Environment:
         keep_trailing_newline=True,
         trim_blocks=True,
         lstrip_blocks=True,
-        autoescape=False,
+        autoescape=select_autoescape(),
     )
     env.filters["repr"] = repr
     return env

--- a/scripts/release/build_subpackages.py
+++ b/scripts/release/build_subpackages.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
-import subprocess
+import subprocess  # nosec B404 - used only with fixed argv lists; never shell=True
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -235,7 +235,7 @@ def run_build(job: BuildJob) -> tuple[str, int, str]:
     Returns ``(name, returncode, combined_stderr)`` so the caller can
     collect failures after the pool drains.
     """
-    proc = subprocess.run(
+    proc = subprocess.run(  # nosec B603 - fixed argv; outdir/project_dir are Path instances resolved under BUILD_DIR
         [
             sys.executable,
             "-m",

--- a/scripts/release/prepare_release.py
+++ b/scripts/release/prepare_release.py
@@ -35,9 +35,10 @@ from __future__ import annotations
 
 import argparse
 import re
-import subprocess
+import subprocess  # nosec B404 - used only via `_run` with list-form argv; never shell=True
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -70,8 +71,11 @@ def _validate_new_version(new: str, current: str) -> None:
 
 def _version_on_pypi(version: str) -> bool:
     url = f"https://pypi.org/pypi/aws-resource-validator/{version}/json"
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "pypi.org":
+        raise ValueError(f"refusing non-pypi.org URL: {url!r}")
     try:
-        with urllib.request.urlopen(
+        with urllib.request.urlopen(  # nosec B310 - scheme+host validated above
             urllib.request.Request(url, method="HEAD"), timeout=15
         ) as response:
             return response.status == 200
@@ -122,7 +126,7 @@ def _run(cmd: list[str], *, cwd: Path | None = None, dry_run: bool = False) -> N
         print(f"  [dry-run] would run: {display}")
         return
     print(f"  $ {display}")
-    result = subprocess.run(cmd, cwd=cwd or REPO_ROOT, check=False)
+    result = subprocess.run(cmd, cwd=cwd or REPO_ROOT, check=False)  # nosec B603 - cmd is a list built from sys.executable + module paths at call sites; shell=False
     if result.returncode != 0:
         raise SystemExit(
             f"command failed (exit {result.returncode}): {display}"

--- a/scripts/release/publish_wheels.py
+++ b/scripts/release/publish_wheels.py
@@ -30,10 +30,11 @@ import concurrent.futures
 import os
 import pathlib
 import re
-import subprocess
+import subprocess  # nosec B404 - used only with fixed argv lists; never shell=True
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Iterable
 
@@ -56,9 +57,12 @@ def parse_wheel(path: pathlib.Path) -> tuple[str, str] | None:
 
 
 def _pypi_head(url: str, timeout: float = 15) -> bool:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "pypi.org":
+        raise ValueError(f"refusing non-pypi.org URL: {url!r}")
     request = urllib.request.Request(url, method="HEAD")
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310 - scheme+host validated above
             return response.status == 200
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
@@ -109,7 +113,7 @@ def run_twine(chunk: list[pathlib.Path], repository_url: str | None) -> subproce
     if repository_url:
         args.extend(["--repository-url", repository_url])
     args.extend(str(p) for p in chunk)
-    return subprocess.run(args, env=env, capture_output=True, text=True, check=False)
+    return subprocess.run(args, env=env, capture_output=True, text=True, check=False)  # nosec B603 - fixed argv; repository_url is a twine flag value, shell=False
 
 
 def looks_like_429(output: str) -> bool:

--- a/scripts/release/smoke_test.py
+++ b/scripts/release/smoke_test.py
@@ -15,7 +15,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import subprocess
+import subprocess  # nosec B404 - used only with fixed argv lists; never shell=True
 import sys
 import tempfile
 import venv
@@ -74,17 +74,17 @@ def main(argv: list[str] | None = None) -> int:
 
         print(f"[smoke] venv: {venv_dir}")
         print(f"[smoke] installing {main_wheel.name} + {service_wheel.name}")
-        subprocess.run(
+        subprocess.run(  # nosec B603 - fixed argv; paths are venv-derived Path objects
             [str(python), "-m", "pip", "install", "--quiet", str(main_wheel), str(service_wheel)],
             check=True,
         )
 
         print("[smoke] cross-namespace import")
-        subprocess.run([str(python), "-c", IMPORT_SCRIPT], check=True)
+        subprocess.run([str(python), "-c", IMPORT_SCRIPT], check=True)  # nosec B603 - IMPORT_SCRIPT is a module-level literal
 
         print("[smoke] arv-generate without [generator] extra")
         arv_cmd = venv_dir / ("Scripts" if sys.platform == "win32" else "bin") / "arv-generate"
-        subprocess.run([str(python), "-c", ARV_WITHOUT_GENERATOR, str(arv_cmd)], check=True)
+        subprocess.run([str(python), "-c", ARV_WITHOUT_GENERATOR, str(arv_cmd)], check=True)  # nosec B603 - script literal; arv_cmd is a venv-derived Path
 
     print("[smoke] all checks passed")
     return 0

--- a/tests/unit/pipeline_a/test_github_source.py
+++ b/tests/unit/pipeline_a/test_github_source.py
@@ -74,7 +74,7 @@ def test_rate_limit_triggers_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
 @responses.activate
 def test_includes_bearer_token_header() -> None:
     responses.get(_BASE_URL, json=[])
-    source = GitHubBotocoreSource(token="tok-123")
+    source = GitHubBotocoreSource(token="tok-123")  # nosec B106 - placeholder; @responses.activate mocks the request
     list(source.iter_services())
     assert responses.calls[0].request.headers["Authorization"] == "Bearer tok-123"
 


### PR DESCRIPTION
Excludes tests/ and the generated trees from the Bandit scan and skips B101 globally (pytest is built on `assert`). For the remaining findings, adds a urlparse-based scheme+host guard before urlopen in the release scripts and annotates each subprocess.run with `# nosec B<code>` plus the invariant that makes it safe. Switches the Jinja env to `select_autoescape()` — generator output stays byte-identical because our `.py.j2` templates aren't in the HTML/XML whitelist.